### PR TITLE
Implement trace from ast$exp to modLang$exp

### DIFF
--- a/compiler/backend/backend_commonScript.sml
+++ b/compiler/backend/backend_commonScript.sml
@@ -26,11 +26,12 @@ val _ = Define`closure_tag = 30:num`
 val _ = Define`partial_app_tag = 31:num`
 val _ = Define`clos_tag_shift tag = if tag < 30 then tag:num else tag+2`
 
+(* Trace of an expression through the compiler, for exploring transformations *)
 val _ = Datatype`
-  trace =
+  tra =
     | Empty
-    | Cons trace num
-    | Union trace trace`
+    | Cons tra num
+    | Union tra tra`
 
 val bool_to_tag_def = Define`
   bool_to_tag b = if b then true_tag else false_tag`

--- a/compiler/backend/modLangScript.sml
+++ b/compiler/backend/modLangScript.sml
@@ -1,4 +1,5 @@
 open preamble astTheory;
+open backend_commonTheory;
 
 val _ = new_theory "modLang";
 
@@ -21,18 +22,18 @@ val _ = set_grammar_ancestry ["ast"];
 
 val _ = Datatype`
  exp =
-    Raise exp
-  | Handle exp ((pat # exp) list)
-  | Lit lit
-  | Con (((modN,conN) id) option) (exp list)
-  | Var_local varN
-  | Var_global num
-  | Fun varN exp
-  | App op (exp list)
-  | If exp exp exp
-  | Mat exp ((pat # exp) list)
-  | Let (varN option) exp exp
-  | Letrec ((varN # varN # exp) list) exp`;
+    Raise tra exp
+  | Handle tra exp ((pat # exp) list)
+  | Lit tra lit
+  | Con tra (((modN,conN) id) option) (exp list)
+  | Var_local tra varN
+  | Var_global tra num
+  | Fun tra varN exp
+  | App tra op (exp list)
+  | If tra exp exp exp
+  | Mat tra exp ((pat # exp) list)
+  | Let tra (varN option) exp exp
+  | Letrec tra ((varN # varN # exp) list) exp`;
 
 val exp_size_def = definition"exp_size_def";
 

--- a/compiler/backend/mod_to_conScript.sml
+++ b/compiler/backend/mod_to_conScript.sml
@@ -42,38 +42,38 @@ val compile_pat_def = tDefine"compile_pat"`
    decide_tac);
 
 val compile_exp_def = tDefine"compile_exp"`
-  (compile_exp tagenv (Raise e) = Raise (compile_exp tagenv e))
+  (compile_exp tagenv (Raise _ e) = Raise (compile_exp tagenv e))
   ∧
-  (compile_exp tagenv (Handle e pes) =
+  (compile_exp tagenv (Handle _ e pes) =
    Handle (compile_exp tagenv e) (compile_pes tagenv pes))
   ∧
-  (compile_exp tagenv ((Lit l):modLang$exp) = (Lit l:conLang$exp))
+  (compile_exp tagenv ((Lit _ l):modLang$exp) = (Lit l:conLang$exp))
   ∧
-  (compile_exp tagenv (Con cn es) =
+  (compile_exp tagenv (Con _ cn es) =
    Con (lookup_tag_env cn tagenv) (compile_exps tagenv es))
   ∧
-  (compile_exp tagenv (Var_local x) = Var_local x)
+  (compile_exp tagenv (Var_local _ x) = Var_local x)
   ∧
-  (compile_exp tagenv (Var_global n) = Var_global n)
+  (compile_exp tagenv (Var_global _ n) = Var_global n)
   ∧
-  (compile_exp tagenv (Fun x e) =
+  (compile_exp tagenv (Fun _ x e) =
    Fun x (compile_exp tagenv e))
   ∧
-  (compile_exp tagenv (App op es) =
+  (compile_exp tagenv (App _ op es) =
    App (Op op) (compile_exps tagenv es))
   ∧
-  (compile_exp tagenv (If e1 e2 e3) =
+  (compile_exp tagenv (If _ e1 e2 e3) =
    Mat (compile_exp tagenv e1)
      [(Pcon(SOME(true_tag,TypeId(Short"bool")))[],compile_exp tagenv e2);
       (Pcon(SOME(false_tag,TypeId(Short"bool")))[],compile_exp tagenv e3)])
   ∧
-  (compile_exp tagenv (Mat e pes) =
+  (compile_exp tagenv (Mat _ e pes) =
    Mat (compile_exp tagenv e) (compile_pes tagenv pes))
   ∧
-  (compile_exp tagenv (Let a e1 e2) =
+  (compile_exp tagenv (Let _ a e1 e2) =
    Let a (compile_exp tagenv e1) (compile_exp tagenv e2))
   ∧
-  (compile_exp tagenv (Letrec funs e) =
+  (compile_exp tagenv (Letrec _ funs e) =
    Letrec (compile_funs tagenv funs) (compile_exp tagenv e))
   ∧
   (compile_exps tagenv [] = [])


### PR DESCRIPTION
1. Converts line annotations (Lannot) to trace
2. Add these traces to modLang expressions

Squashed commit messages:

Add trace to modLang datatype

Try to add position information in source_to_mod

So far I can't get it to compile.

Accept mod_lang values with trace in mod_to_con

Start passing Line Annotations into compile sunctions in source_to_mod

Pass actual position information to modLang

Shorten name of trace datatype

Add trace to boolean type

Stylefix

Make type unambiguous

Remove comments

Trailing whitespace

Remove trace from ast pattern, and pass trace to new variables