### PR TITLE
Create presLang, the presentation language, and ast -> presLang function

### DIFF
--- a/compiler/backend/presLangScript.sml
+++ b/compiler/backend/presLangScript.sml
@@ -1,0 +1,69 @@
+open preamble astTheory jsonTheory;
+
+val _ = new_theory"presLang";
+
+(* 
+* presLang is a presentation language, encompassing many intermediate languages
+* of the compiler, adopting their constructors. The purpose of presLang is to be
+* an intermediate representation between an intermediate language of the
+* compiler and JSON. By translating an intermediate language to presLang, it can
+* be given a JSON representation by calling to_json on the presLang
+* representation. presLang has no semantics, as it is never evaluated, and may
+* therefore mix operators, declarations, patterns and expressions.
+*)
+
+val _ = Datatype`
+  exp =
+    (* An entire program. Is divided into any number of top level declarations. *)
+    | Prog (exp(*top*) list)
+    (* Top level declarations. May contain module, and spec. The exp is always a declaration. *)
+    | Tdec exp(*dec*)
+    | Tmod modN (specs option) (exp(*dec*) list)
+    (* Declarations *)
+    | Dlet exp(*pat*) exp(*exp*)
+    | Dletrec ((varN # varN # exp(*exp*)) list)
+    | Dtype type_def
+    | Dtabbrev (tvarN list) typeN t
+    | Dexn conN (t list)
+    (* Patterns *)
+    | Pvar varN
+    | Plit lit
+    | Pcon (((modN, conN) id) option) (exp(*pat*) list)
+    | Pref exp(*pat*)
+    | Ptannot exp(*pat*) t
+    (* Expressions *)
+    | Raise exp
+    | Handle exp ((exp(*pat*) # exp) list)
+    | Var ((modN, varN) id)
+    | Lit lit
+      (* Constructor application.
+       A Nothing constructor indicates a tuple pattern. *)
+    | Con (((modN, conN) id) option) (exp list)
+      (* Application of a primitive operator to arguments.
+       Includes function application. *)
+    | App op (exp list)
+    | Fun varN exp
+      (* Logical operations (and, or) *)
+    | Log lop exp exp
+    | If exp exp exp
+      (* Pattern matching *)
+    | Mat exp ((exp(*pat*) # exp) list)
+      (* A let expression
+         A Nothing value for the binding indicates that this is a
+         sequencing expression, that is: (e1; e2). *)
+    | Let (varN option) exp exp
+      (* Local definition of (potentially) mutually recursive
+         functions.
+         The first varN is the function's name, and the second varN
+         is its parameter. *)
+    | Letrec ((varN # varN # exp) list) exp
+    | Tannot exp t
+      (* Location annotated expressions, not expected in source programs *)
+    | Lannot exp locn`;
+
+(* TODO: Implement to_json based on presLang structure. *)
+val to_json_def = tDefine "to_json"`
+  to_json _ = json$Null`
+  cheat;
+
+val _ = export_theory();

--- a/compiler/testingScript.sml
+++ b/compiler/testingScript.sml
@@ -8,12 +8,17 @@ open jsonTheory
 
 (* COMPILING *)
 val _ = Define`
-  basic_prog = "val (x,y) = (3 + 5, 1); val y = \"hello\";"`;
-val _ = Define`
   parse p = parse_prog (MAP FST (lexer_fun p))`;
+val _ = Define`
+  basic_prog = "1; val (x,y) = let val my1 = 1 in (3 + 5 mod 10, my1) end; fun foo(x:int) = [x,x,x]; val x = String.size \"bob\"; exception ExplorerException of string; fun mk_ref(x,v) = x := v"`;
+val _ = Define`
+  parsed_basic =
+    case parse basic_prog of
+         NONE => [] 
+       | SOME x => x`;
 
-EVAL ``parse basic_prog``;
-
+EVAL ``parsed_basic``;
+EVAL ``source_to_mod$ast_to_pres parsed_basic``;
 
 (* JSON *)
 val _ = Define `


### PR DESCRIPTION
Makes presLang, which is intended to capture all features of several
intermediate languages. In particular, it will capture all those that
are mainly functional in style. As such, it might be extended with
several constructors.

presLang has only one data type, exp, as it lacks semantics. The purpose
of preslang is for presenting tha program structure as a tree, not to
evaluate it.

This change includes some test cases for presLang, in testScript.