### PR TITLE
Implemented traces for conLang and decLang

### DIFF
--- a/compiler/backend/conLangScript.sml
+++ b/compiler/backend/conLangScript.sml
@@ -1,4 +1,5 @@
 open preamble
+open backend_commonTheory
 
 val _ = numLib.prefer_num();
 
@@ -26,19 +27,19 @@ val _ = Datatype`
   | Pref pat`;
 
 val _ = Datatype`
- exp =
-  | Raise exp
-  | Handle exp ((pat # exp) list)
-  | Lit lit
-  | Con ((num # tid_or_exn)option) (exp list)
-  | Var_local varN
-  | Var_global num
-  | Fun varN exp
-  | App op (exp list)
-  | Mat exp ((pat # exp) list)
-  | Let (varN option) exp exp
-  | Letrec ((varN # varN # exp) list) exp
-  | Extend_global num`;
+   exp =
+  | Raise tra exp
+  | Handle tra exp ((pat # exp) list)
+  | Lit tra lit
+  | Con tra ((num # tid_or_exn)option) (exp list)
+  | Var_local tra varN
+  | Var_global tra num
+  | Fun tra varN exp
+  | App tra op (exp list)
+  | Mat tra exp ((pat # exp) list)
+  | Let tra (varN option) exp exp
+  | Letrec tra ((varN # varN # exp) list) exp
+  | Extend_global tra num`;
 
 val exp_size_def = definition"exp_size_def";
 

--- a/compiler/backend/conLangScript.sml
+++ b/compiler/backend/conLangScript.sml
@@ -27,7 +27,7 @@ val _ = Datatype`
   | Pref pat`;
 
 val _ = Datatype`
-   exp =
+ exp =
   | Raise tra exp
   | Handle tra exp ((pat # exp) list)
   | Lit tra lit

--- a/compiler/backend/con_to_decScript.sml
+++ b/compiler/backend/con_to_decScript.sml
@@ -10,51 +10,58 @@ val _ = new_theory"con_to_dec"
  *)
 
 val _ = Define`
-  (init_globals [] idx =
-   Con NONE [])
+  (init_globals tra tidx [] idx =
+   Con (mk_cons tra tidx) NONE [])
   ∧
-  (init_globals (x::vars) idx =
-   Let NONE (App (Init_global_var idx) [Var_local x]) (init_globals vars (idx+1)))`;
+  (init_globals tra tidx (x::vars) idx =
+   Let (mk_cons tra tidx) NONE (App (mk_cons tra (tidx+1)) (Init_global_var idx)
+   [Var_local (mk_cons tra (tidx+2)) x]) (init_globals tra (tidx+3) vars (idx+1)))`;
 
 
 val _ = Define `
-  (init_global_funs next [] = Con NONE [])
+  (init_global_funs tra tidx next [] = Con (mk_cons tra tidx) NONE [])
   ∧
-  (init_global_funs next ((f,x,e)::funs) =
-   Let NONE (App (Init_global_var next) [Fun x e]) (init_global_funs (next+1) funs))`;
-
+  (init_global_funs tra tidx next ((f,x,e)::funs) =
+   Let (mk_cons tra tidx) NONE (App (mk_cons tra (tidx+1)) (Init_global_var next) [Fun (mk_cons tra (tidx+2)) x e]) (init_global_funs tra (tidx+3) (next+1) funs))`;
+(*TODO: We should check whether introducing a trace to Dletrec and is sensible, in
+  * that case we should change from passing on Empty into init_global_funs to
+  * the correct trace *)
 val _ = Define `
-  (compile_decs next [] = Con NONE [])
+  (compile_decs next [] = Con Empty NONE [])
   ∧
   (compile_decs next (d::ds) =
    case d of
    | Dlet n e =>
      let vars = (GENLIST (λn. STRCAT"x"(num_to_dec_string n)) n) in
-       Let NONE (Mat e [(Pcon NONE (MAP Pvar vars), init_globals vars next)])
+       Let (mk_cons Empty 1) NONE (Mat (mk_cons Empty 2) e [(Pcon NONE (MAP Pvar
+       vars), init_globals Empty 3 vars next)])
          (compile_decs (next+n) ds)
    | Dletrec funs =>
      let n = (LENGTH funs) in
-       Let NONE (init_global_funs next funs) (compile_decs (next+n) ds))`;
+       Let (mk_cons Empty 1) NONE (init_global_funs Empty 2 next funs) (compile_decs (next+n) ds))`;
 
+(* Since the Lets, cons and var_local doesn't have a trace, nor does the prompts we'll leave
+* them as empty *)
 val _ = Define `
   (compile_prompt none_tag some_tag next prompt =
    case prompt of
     | Prompt ds =>
       let n = (num_defs ds) in
         (next+n,
-         Let NONE (Extend_global n)
-           (Handle (Let NONE (compile_decs next ds)
-                     (Con (SOME none_tag) []))
+         Let Empty NONE (Extend_global Empty n)
+           (Handle Empty (Let Empty NONE (compile_decs next ds)
+                     (Con Empty (SOME none_tag) []))
              [(Pvar "x",
-               Con (SOME some_tag) [Var_local "x"])])))`;
+               Con Empty (SOME some_tag) [Var_local Empty "x"])])))`;
 
 val _ = Define`
-  (compile_prog none_tag some_tag next [] = (next, Con (SOME none_tag) []))
+  (compile_prog none_tag some_tag next [] = (next, Con Empty (SOME none_tag) []))
   ∧
   (compile_prog none_tag some_tag next (p::ps) =
    let (next',p') = compile_prompt none_tag some_tag next p in
    let (next'',ps') = compile_prog none_tag some_tag next' ps in
-     (next'',Mat p' [(Pcon (SOME none_tag) [], ps'); (Pvar "x", Var_local "x")]))`;
+     (next'',Mat Empty p' [(Pcon (SOME none_tag) [], ps'); (Pvar "x", Var_local
+     Empty "x")]))`;
 
 val _ = Define`
   compile =

--- a/compiler/backend/con_to_decScript.sml
+++ b/compiler/backend/con_to_decScript.sml
@@ -23,9 +23,10 @@ val _ = Define `
   ∧
   (init_global_funs tra tidx next ((f,x,e)::funs) =
    Let (mk_cons tra tidx) NONE (App (mk_cons tra (tidx+1)) (Init_global_var next) [Fun (mk_cons tra (tidx+2)) x e]) (init_global_funs tra (tidx+3) (next+1) funs))`;
-(*TODO: We should check whether introducing a trace to Dletrec and is sensible, in
-  * that case we should change from passing on Empty into init_global_funs to
-  * the correct trace *)
+
+(*TODO: We should find a solution to add traces to declarations based on the
+ * expression(s) they contain. Once we have a trace we should change from passing
+ * on Empty into init_global_funs to the correct trace *)
 val _ = Define `
   (compile_decs next [] = Con Empty NONE [])
   ∧
@@ -40,8 +41,7 @@ val _ = Define `
      let n = (LENGTH funs) in
        Let (mk_cons Empty 1) NONE (init_global_funs Empty 2 next funs) (compile_decs (next+n) ds))`;
 
-(* Since the Lets, cons and var_local doesn't have a trace, nor does the prompts we'll leave
-* them as empty *)
+(* TODO: Since the Lets, cons, var_local and prompts don't have a trace we'll leave them as empty *)
 val _ = Define `
   (compile_prompt none_tag some_tag next prompt =
    case prompt of
@@ -60,8 +60,7 @@ val _ = Define`
   (compile_prog none_tag some_tag next (p::ps) =
    let (next',p') = compile_prompt none_tag some_tag next p in
    let (next'',ps') = compile_prog none_tag some_tag next' ps in
-     (next'',Mat Empty p' [(Pcon (SOME none_tag) [], ps'); (Pvar "x", Var_local
-     Empty "x")]))`;
+     (next'',Mat Empty p' [(Pcon (SOME none_tag) [], ps'); (Pvar "x", Var_local Empty "x")]))`;
 
 val _ = Define`
   compile =

--- a/compiler/backend/dec_to_exhScript.sml
+++ b/compiler/backend/dec_to_exhScript.sml
@@ -51,13 +51,13 @@ val _ = Define `
     | _ => F))`;
 
 val add_default_def = Define `
-  (add_default is_handle is_exh (pes:(conLang$pat#conLang$exp)list) =
+  (add_default tra is_handle is_exh (pes:(conLang$pat#conLang$exp)list) =
    if is_exh then
      pes
    else if is_handle then
-     pes ++ [(Pvar "x", Raise (Var_local "x"))]
+     pes ++ [(Pvar "x", Raise (mk_cons tra 1) (Var_local (mk_cons tra 2) "x"))]
    else
-     pes ++ [(Pvar "x", Raise (Con (SOME (bind_tag, (TypeId (Short "option")))) []))])`;
+     pes ++ [(Pvar "x", Raise (mk_cons tra 1) (Con (mk_cons tra 2) (SOME (bind_tag, (TypeId (Short "option")))) []))])`;
 
 val _ = tDefine"compile_pat"`
   (compile_pat (Pvar x) = Pvar x)
@@ -81,14 +81,14 @@ val _ = tDefine"compile_pat"`
    decide_tac);
 
 val e2sz_def = Lib.with_flag (computeLib.auto_import_definitions, false) (tDefine"e2sz"`
-  (e2sz (conLang$Raise e) = e2sz e + 1) ∧
-  (e2sz (Letrec funs e) = e2sz e + f2sz funs + 1) ∧
-  (e2sz (Mat e pes) = e2sz e + p2sz pes + 4) ∧
-  (e2sz (Handle e pes) = e2sz e + p2sz pes + 4) ∧
-  (e2sz (App op es) = l2sz es + 1) ∧
-  (e2sz (Let x e1 e2) = e2sz e1 + e2sz e2 + 1) ∧
-  (e2sz (Fun x e) = e2sz e + 1) ∧
-  (e2sz (Con t es) = l2sz es + 1) ∧
+  (e2sz (conLang$Raise _ e) = e2sz e + 1) ∧
+  (e2sz (Letrec _ funs e) = e2sz e + f2sz funs + 1) ∧
+  (e2sz (Mat _ e pes) = e2sz e + p2sz pes + 4) ∧
+  (e2sz (Handle _ e pes) = e2sz e + p2sz pes + 4) ∧
+  (e2sz (App _ op es) = l2sz es + 1) ∧
+  (e2sz (Let _ x e1 e2) = e2sz e1 + e2sz e2 + 1) ∧
+  (e2sz (Fun _ x e) = e2sz e + 1) ∧
+  (e2sz (Con _ t es) = l2sz es + 1) ∧
   (e2sz _ = (0:num)) ∧
   (l2sz [] = 0) ∧
   (l2sz (e::es) = e2sz e + l2sz es + 1) ∧
@@ -108,46 +108,46 @@ val p2sz_append = Q.prove(
   Cases >> simp[e2sz_def])
 
 val compile_exp_def = tDefine"compile_exp"`
-  (compile_exp exh (Raise e) =
+  (compile_exp exh (Raise _ e) =
    Raise (compile_exp exh e))
   ∧
-  (compile_exp exh (Handle e pes) =
+  (compile_exp exh (Handle t e pes) =
    Handle (compile_exp exh e)
-     (compile_pes exh (add_default T (exhaustive_match exh (MAP FST pes)) pes)))
+     (compile_pes exh (add_default t T (exhaustive_match exh (MAP FST pes)) pes)))
   ∧
-  (compile_exp exh (Lit l) =
+  (compile_exp exh (Lit _ l) =
    Lit l)
   ∧
-  (compile_exp exh (Con NONE es) =
+  (compile_exp exh (Con _ NONE es) =
    Con tuple_tag (compile_exps exh es))
   ∧
-  (compile_exp exh (Con (SOME (tag,_)) es) =
+  (compile_exp exh (Con _ (SOME (tag,_)) es) =
    Con tag (compile_exps exh es))
   ∧
-  (compile_exp exh (Var_local x) =
+  (compile_exp exh (Var_local _ x) =
    Var_local x)
   ∧
-  (compile_exp exh (Var_global x) =
+  (compile_exp exh (Var_global _ x) =
    Var_global x)
   ∧
-  (compile_exp exh (Fun x e) =
+  (compile_exp exh (Fun _ x e) =
    Fun x (compile_exp exh e))
   ∧
-  (compile_exp exh (App op es) =
+  (compile_exp exh (App _ op es) =
    App op (compile_exps exh es))
   ∧
-  (compile_exp exh (Mat e pes) =
+  (compile_exp exh (Mat t e pes) =
    Mat (compile_exp exh e)
-     (compile_pes exh (add_default F (exhaustive_match exh (MAP FST pes)) pes)))
+     (compile_pes exh (add_default t F (exhaustive_match exh (MAP FST pes)) pes)))
   ∧
-  (compile_exp exh (Let x e1 e2) =
+  (compile_exp exh (Let _ x e1 e2) =
    Let x (compile_exp exh e1) (compile_exp exh e2))
   ∧
-  (compile_exp exh (Letrec funs e) =
+  (compile_exp exh (Letrec _ funs e) =
    Letrec (compile_funs exh funs)
      (compile_exp exh e))
   ∧
-  (compile_exp exh (Extend_global n) =
+  (compile_exp exh (Extend_global _ n) =
    Extend_global n)
   ∧
   (compile_exps exh [] = [])

--- a/compiler/backend/mod_to_conScript.sml
+++ b/compiler/backend/mod_to_conScript.sml
@@ -42,39 +42,39 @@ val compile_pat_def = tDefine"compile_pat"`
    decide_tac);
 
 val compile_exp_def = tDefine"compile_exp"`
-  (compile_exp tagenv (Raise _ e) = Raise (compile_exp tagenv e))
+  (compile_exp tagenv (Raise t e) = Raise t (compile_exp tagenv e))
   ∧
-  (compile_exp tagenv (Handle _ e pes) =
-   Handle (compile_exp tagenv e) (compile_pes tagenv pes))
+  (compile_exp tagenv (Handle t e pes) =
+   Handle t (compile_exp tagenv e) (compile_pes tagenv pes))
   ∧
-  (compile_exp tagenv ((Lit _ l):modLang$exp) = (Lit l:conLang$exp))
+  (compile_exp tagenv ((Lit t l):modLang$exp) = (Lit t l:conLang$exp))
   ∧
-  (compile_exp tagenv (Con _ cn es) =
-   Con (lookup_tag_env cn tagenv) (compile_exps tagenv es))
+  (compile_exp tagenv (Con t cn es) =
+   Con t (lookup_tag_env cn tagenv) (compile_exps tagenv es))
   ∧
-  (compile_exp tagenv (Var_local _ x) = Var_local x)
+  (compile_exp tagenv (Var_local t x) = Var_local t x)
   ∧
-  (compile_exp tagenv (Var_global _ n) = Var_global n)
+  (compile_exp tagenv (Var_global t n) = Var_global t n)
   ∧
-  (compile_exp tagenv (Fun _ x e) =
-   Fun x (compile_exp tagenv e))
+  (compile_exp tagenv (Fun t x e) =
+   Fun t x (compile_exp tagenv e))
   ∧
-  (compile_exp tagenv (App _ op es) =
-   App (Op op) (compile_exps tagenv es))
+  (compile_exp tagenv (App t op es) =
+   App t (Op op) (compile_exps tagenv es))
   ∧
-  (compile_exp tagenv (If _ e1 e2 e3) =
-   Mat (compile_exp tagenv e1)
+  (compile_exp tagenv (If t e1 e2 e3) =
+   Mat t (compile_exp tagenv e1)
      [(Pcon(SOME(true_tag,TypeId(Short"bool")))[],compile_exp tagenv e2);
       (Pcon(SOME(false_tag,TypeId(Short"bool")))[],compile_exp tagenv e3)])
   ∧
-  (compile_exp tagenv (Mat _ e pes) =
-   Mat (compile_exp tagenv e) (compile_pes tagenv pes))
+  (compile_exp tagenv (Mat t e pes) =
+   Mat t (compile_exp tagenv e) (compile_pes tagenv pes))
   ∧
-  (compile_exp tagenv (Let _ a e1 e2) =
-   Let a (compile_exp tagenv e1) (compile_exp tagenv e2))
+  (compile_exp tagenv (Let t a e1 e2) =
+   Let t a (compile_exp tagenv e1) (compile_exp tagenv e2))
   ∧
-  (compile_exp tagenv (Letrec _ funs e) =
-   Letrec (compile_funs tagenv funs) (compile_exp tagenv e))
+  (compile_exp tagenv (Letrec t funs e) =
+   Letrec t (compile_funs tagenv funs) (compile_exp tagenv e))
   ∧
   (compile_exps tagenv [] = [])
   ∧

--- a/compiler/backend/presLangScript.sml
+++ b/compiler/backend/presLangScript.sml
@@ -29,9 +29,10 @@ val _ = Datatype`
     | Dletrec ((varN # varN # exp(*exp*)) list)
     | Dtype (modN list)
     | Dexn (modN list) conN (t list)
-    (* TODO: Consider doing what we did with op above for the patterns below*)
     | Pvar varN
     | Plit lit
+    (* TODO: Consider doing what we did with op above for the patterns below, in
+     * order to avoid creating separate constructors for separate languages *)
     | ModPcon (((modN, conN) id) option) (exp(*pat*) list)
     | ConPcon ((num # tid_or_exn) option) (exp(*pat*) list)
     | Pref exp(*pat*)
@@ -191,13 +192,15 @@ val con_to_pres_def = Define`
   con_to_pres prompts = Prog (MAP con_to_pres_prompt prompts)`;
 
 (* pres_to_json *)
-(* TODO: Add words, add ConCon and ConPcon *)
+(* TODO: Add words *)
 val lit_to_value_def = Define`
   (lit_to_value (IntLit i) = Int i)
   /\
   (lit_to_value (Char c) = String [c])
   /\
-  (lit_to_value (StrLit s) = String s)`;
+  (lit_to_value (StrLit s) = String s)
+  /\
+  (lit_to_value _ = String "word8/64")`;
 
 (* Create a new json$Object with keys and values as in the tuples. Every object
 * has constructor name field, cons *)

--- a/compiler/backend/presLangScript.sml
+++ b/compiler/backend/presLangScript.sml
@@ -1,5 +1,5 @@
 open preamble astTheory jsonTheory backend_commonTheory;
-open modLangTheory;
+open conLangTheory modLangTheory;
 
 val _ = new_theory"presLang";
 
@@ -16,7 +16,8 @@ val _ = new_theory"presLang";
 (* Special operator wrapper for presLang *)
 val _ = Datatype`
   op =
-    Ast ast$op`;
+    | Ast ast$op
+    | Conlang conLang$op`;
 
 val _ = Datatype`
   exp =
@@ -28,10 +29,11 @@ val _ = Datatype`
     | Dletrec ((varN # varN # exp(*exp*)) list)
     | Dtype (modN list)
     | Dexn (modN list) conN (t list)
-    (* Patterns *)
+    (* TODO: Consider doing what we did with op above for the patterns below*)
     | Pvar varN
     | Plit lit
-    | Pcon (((modN, conN) id) option) (exp(*pat*) list)
+    | ModPcon (((modN, conN) id) option) (exp(*pat*) list)
+    | ConPcon ((num # tid_or_exn) option) (exp(*pat*) list)
     | Pref exp(*pat*)
     | Ptannot exp(*pat*) t
     (* Expressions *)
@@ -39,10 +41,12 @@ val _ = Datatype`
     | Handle tra exp ((exp(*pat*) # exp) list)
     | Var_local tra varN
     | Var_global tra num
+    | Extend_global tra num (* Introduced in conLang *)
     | Lit tra lit
       (* Constructor application.
        A Nothing constructor indicates a tuple pattern. *)
-    | Con tra (((modN, conN) id) option) (exp list)
+    | ModCon tra (((modN, conN) id) option) (exp list)
+    | ConCon tra ((num # tid_or_exn) option) (exp list)
       (* Application of a primitive operator to arguments.
        Includes function application. *)
     | App tra op (exp list)
@@ -71,7 +75,7 @@ val mod_to_pres_pat_def = tDefine "mod_to_pres_pat"`
     case p of
        | ast$Pvar varN => presLang$Pvar varN
        | Plit lit => Plit lit
-       | Pcon id pats => Pcon id (MAP mod_to_pres_pat pats)
+       | Pcon id pats => ModPcon id (MAP mod_to_pres_pat pats)
        | Pref pat => Pref (mod_to_pres_pat pat)
        (* Won't happen, these are removed in compilation from source to mod. *)
        | Ptannot pat t => Ptannot (mod_to_pres_pat pat) t`
@@ -85,7 +89,7 @@ val mod_to_pres_exp_def = tDefine"mod_to_pres_exp"`
   /\
   (mod_to_pres_exp (Lit tra lit) = Lit tra lit)
   /\
-  (mod_to_pres_exp (Con tra id_opt exps) = Con tra id_opt (MAP mod_to_pres_exp exps))
+  (mod_to_pres_exp (Con tra id_opt exps) = ModCon tra id_opt (MAP mod_to_pres_exp exps))
   /\
   (mod_to_pres_exp (Var_local tra varN) = Var_local tra varN)
   /\
@@ -131,8 +135,63 @@ val mod_to_pres_prompt_def = Define`
 val mod_to_pres_def = Define`
   mod_to_pres prompts = Prog (MAP mod_to_pres_prompt prompts)`;
 
+(* con_to_pres *)
+val con_to_pres_pat_def = tDefine"con_to_pres_pat"`
+  con_to_pres_pat p =
+    case p of
+       | conLang$Pvar varN => presLang$Pvar varN
+       | Plit lit => Plit lit
+       | Pcon opt ps => ConPcon opt (MAP con_to_pres_pat ps)
+       | Pref pat => Pref (con_to_pres_pat pat)`
+    cheat;
+
+val con_to_pres_exp_def = tDefine"con_to_pres_exp"`
+  (con_to_pres_exp (conLang$Raise t e) = Raise t (con_to_pres_exp e))
+  /\ 
+  (con_to_pres_exp (Handle t e pes) = Handle t (con_to_pres_exp e) (con_to_pres_pes pes))
+  /\
+  (con_to_pres_exp (Lit t l) = Lit t l)
+  /\
+  (con_to_pres_exp (Con t ntOpt exps) = ConCon t ntOpt (MAP con_to_pres_exp
+  exps))
+  /\ 
+  (con_to_pres_exp (Var_local t varN) = Var_local t varN)
+  /\
+  (con_to_pres_exp (Var_global t num) = Var_global t num)
+  /\
+  (con_to_pres_exp (Fun t varN e) = Fun t varN (con_to_pres_exp e))
+  /\
+  (con_to_pres_exp (App t op exps) = App t (Conlang op) (MAP con_to_pres_exp exps))
+  /\
+  (con_to_pres_exp (Mat t e pes) = Mat t (con_to_pres_exp e) (con_to_pres_pes pes))
+  /\
+  (con_to_pres_exp (Let t varN e1 e2) = Let t varN (con_to_pres_exp e1)
+  (con_to_pres_exp e2))
+  /\ 
+  (con_to_pres_exp (Letrec t funs e) = Letrec t (MAP (\(v1,v2,e).(v1,v2,con_to_pres_exp e)) funs) (con_to_pres_exp e))
+  /\
+  (con_to_pres_exp (Extend_global t num) = Extend_global t num)
+  /\ 
+  (con_to_pres_pes [] = [])
+  /\
+  (con_to_pres_pes ((p,e)::pes) =
+    (con_to_pres_pat p, con_to_pres_exp e)::con_to_pres_pes pes)`
+  cheat; 
+
+val con_to_pres_dec_def = Define`
+  con_to_pres_dec d =
+    case d of
+       | conLang$Dlet num exp => presLang$Dlet num (con_to_pres_exp exp)
+       | Dletrec funs => Dletrec (MAP (\(v1,v2,e). (v1,v2,con_to_pres_exp e)) funs)`; 
+
+val con_to_pres_prompt_def = Define`
+  con_to_pres_prompt (Prompt decs) = Prompt NONE (MAP con_to_pres_dec decs)`;
+
+val con_to_pres_def = Define`
+  con_to_pres prompts = Prog (MAP con_to_pres_prompt prompts)`;
+
 (* pres_to_json *)
-(* TODO: Add words *)
+(* TODO: Add words, add ConCon and ConPcon *)
 val lit_to_value_def = Define`
   (lit_to_value (IntLit i) = Int i)
   /\
@@ -168,6 +227,10 @@ val word_size_to_json_def = Define`
   (word_size_to_json W64 = String "W64")`
 
 val op_to_json_def = Define`
+  (op_to_json (Conlang (Init_global_var num)) = String "Init_global_var")
+  /\
+  (op_to_json (Conlang (Op astop)) = op_to_json (Ast (astop)))
+  /\
   (op_to_json (Ast (Opn Plus)) = String "Plus")
   /\
   (op_to_json (Ast (Opn Minus)) = String "Minus")
@@ -320,6 +383,7 @@ val num_to_hex_def = Define `
 val word_to_hex_string_def = Define `
   word_to_hex_string w = "0x" ++ num_to_hex (w2n (w:'a word))`;
 
+(*TODO: Update lits to be f.e Cons: IntLit, Val: 3 *)
 val lit_to_json_def = Define`
   (lit_to_json (IntLit i) = ("IntLit", Int i))
   /\
@@ -370,13 +434,23 @@ val pres_to_json_def = tDefine"pres_to_json"`
   (pres_to_json (Plit lit) =
       new_obj "Plit" [("pat", Object[lit_to_json lit])])
   /\
-  (pres_to_json (Pcon optTup exps) =
-    let exps' = ("pat", Array (MAP pres_to_json exps)) in
+  (pres_to_json (ModPcon optTup exps) =
+    let exps' = ("pats", Array (MAP pres_to_json exps)) in
     let ids' = case optTup of
                   | NONE => ("modscon", Null)
                   | SOME optUp' => ("modscon", (id_to_object optUp')) in
-
-      new_obj "Pcon" [ids';exps'])
+      new_obj "Pcon-modlang" [ids';exps'])
+  /\
+  (pres_to_json (ConPcon optTup exps) =
+    let exps' = Array (MAP pres_to_json exps) in 
+    let tup' = case optTup of
+                  | NONE => Null
+                  | SOME (num, te) => case te of
+                      | TypeId id => Array [num_to_json num; new_obj "TypeId"
+                      [("id", id_to_object id)]]
+                      | TypeExn id => Array [num_to_json num; new_obj "TypeExn"
+                      [("id", id_to_object id)]] in
+      new_obj "Pcon-conlang" [("numtid",tup');("pats", exps')])
   /\
   (pres_to_json (Pref exp) =
       new_obj "Pref" [("pat", pres_to_json exp)])
@@ -399,15 +473,30 @@ val pres_to_json_def = tDefine"pres_to_json"`
   (pres_to_json (Var_global tra num) =
       new_obj "Var_global" [("tra", trace_to_json tra);("num", num_to_json num)])
   /\
+  (pres_to_json (Extend_global tra num) =
+      new_obj "Extend_global" [("tra", trace_to_json tra);("num", num_to_json
+      num)])
+  /\ 
   (pres_to_json (Lit tra lit) =
       new_obj "Lit" [("tra", trace_to_json tra);lit_to_json lit])
   /\
-  (pres_to_json (Con tra optTup exps) =
+  (pres_to_json (ModCon tra optTup exps) =
     let exps' = ("exps", Array (MAP pres_to_json exps)) in
     let ids' = case optTup of
                   | NONE => ("modscon", Null)
                   | SOME optUp' => ("modscon", (id_to_object optUp')) in
-      new_obj "Con" [("tra", trace_to_json tra);ids';exps'])
+      new_obj "Con-modlang" [("tra", trace_to_json tra);ids';exps'])
+  /\
+  (pres_to_json (ConCon tra optTup exps) =
+    let exps' = Array (MAP pres_to_json exps) in
+    let tup' = case optTup of
+                  | NONE => Null
+                  | SOME (num, te) => case te of
+                      | TypeId id => Array [num_to_json num; new_obj "TypeId"
+                      [("id", id_to_object id)]]
+                      | TypeExn id => Array [num_to_json num; new_obj "TypeExn"
+                      [("id", id_to_object id)]] in
+      new_obj "Con-conlang" [("tra", trace_to_json tra);("numtid",tup');("pats", exps')])
   /\
   (pres_to_json (App tra op exps) =
     let exps' = ("exps", Array (MAP pres_to_json exps)) in

--- a/compiler/backend/source_to_modScript.sml
+++ b/compiler/backend/source_to_modScript.sml
@@ -101,6 +101,7 @@ val compile_exp_def = tDefine"compile_exp"`
   ∧
   (compile_exp t env (Tannot e _) = compile_exp t env e)
   ∧
+  (*TODO: Dont throw away t and look at whether its none*)
   (compile_exp t env (Lannot e (st,en)) =
      compile_exp (mk_cons (mk_cons (mk_cons (mk_cons Empty st.row) st.col) en.row) en.col) env e)
   ∧

--- a/compiler/backend/source_to_modScript.sml
+++ b/compiler/backend/source_to_modScript.sml
@@ -101,7 +101,6 @@ val compile_exp_def = tDefine"compile_exp"`
   ∧
   (compile_exp t env (Tannot e _) = compile_exp t env e)
   ∧
-  (*TODO: Dont throw away t and look at whether its none*)
   (compile_exp t env (Lannot e (st,en)) =
      compile_exp (mk_cons (mk_cons (mk_cons (mk_cons Empty st.row) st.col) en.row) en.col) env e)
   ∧

--- a/compiler/testingScript.sml
+++ b/compiler/testingScript.sml
@@ -6,6 +6,8 @@ open preamble
      cfTacticsBaseLib
 open jsonTheory presLangTheory
 open astTheory source_to_modTheory
+open mod_to_conTheory
+open conLangTheory
 open stringTheory;
 
 val _ = computeLib.add_funs [pat_bindings_def];
@@ -32,9 +34,11 @@ val mod_prog_def = Define`
   mod_prog = SND (source_to_mod$compile source_to_mod$empty_config parsed_basic)`;
 
 EVAL ``mod_prog``;
-(* Test running the compiler backend on the basic program *)
-EVAL ``backend$compile_explorer backend$prim_config parsed_basic``;
 
+val con_prog_def = Define`
+  con_prog = SND (mod_to_con$compile  mod_to_con$empty_config mod_prog)`;
+
+EVAL ``con_prog``;
 (* Convert output to string *)
 EVAL ``append (backend$compile_explorer backend$prim_config parsed_basic)``;
 
@@ -49,18 +53,20 @@ fun explorer q fileN =
       val _ = TextIO.closeOut f
   in ()
   end
-
+(*Sample usage of explorer-function, saving to test.dat *)
+explorer `val x = 1+2;` "test.dat"
 
 (* PRESLANG *)
 (* Test converting mod to pres *)
 EVAL ``mod_to_pres mod_prog``;
-
+(* Test converting con to pres *)
+EVAL ``con_to_pres con_prog``;
 (* Test converting pres to json *)
 EVAL ``pres_to_json (mod_to_pres mod_prog)``;
-
+EVAL ``pres_to_json (con_to_pres con_prog)``;
 (* Test converting json to string *)
 EVAL ``json_to_string (pres_to_json (mod_to_pres mod_prog))``;
-
+EVAL ``append (json_to_string (pres_to_json (con_to_pres con_prog)))``;
 (* Unit test JSON *)
 val _ = Define `
   json =


### PR DESCRIPTION
Updated con_to_dec and dec_to_exh to handle constructors having traces.
Implemented con_to_pres which will work for decLang as well since it
uses conLangs datatypes. Implemented pres_to_json for new constructors.