### PR TITLE
Introducing traces to exhLang

### DIFF
--- a/compiler/backend/dec_to_exhScript.sml
+++ b/compiler/backend/dec_to_exhScript.sml
@@ -108,47 +108,47 @@ val p2sz_append = Q.prove(
   Cases >> simp[e2sz_def])
 
 val compile_exp_def = tDefine"compile_exp"`
-  (compile_exp exh (Raise _ e) =
-   Raise (compile_exp exh e))
+  (compile_exp exh (Raise t e) =
+   Raise t (compile_exp exh e))
   ∧
   (compile_exp exh (Handle t e pes) =
-   Handle (compile_exp exh e)
+   Handle t (compile_exp exh e)
      (compile_pes exh (add_default t T (exhaustive_match exh (MAP FST pes)) pes)))
   ∧
-  (compile_exp exh (Lit _ l) =
-   Lit l)
+  (compile_exp exh (Lit t l) =
+   Lit t l)
   ∧
-  (compile_exp exh (Con _ NONE es) =
-   Con tuple_tag (compile_exps exh es))
+  (compile_exp exh (Con t NONE es) =
+   Con t tuple_tag (compile_exps exh es))
   ∧
-  (compile_exp exh (Con _ (SOME (tag,_)) es) =
-   Con tag (compile_exps exh es))
+  (compile_exp exh (Con t (SOME (tag,_)) es) =
+   Con t tag (compile_exps exh es))
   ∧
-  (compile_exp exh (Var_local _ x) =
-   Var_local x)
+  (compile_exp exh (Var_local t x) =
+   Var_local t x)
   ∧
-  (compile_exp exh (Var_global _ x) =
-   Var_global x)
+  (compile_exp exh (Var_global t x) =
+   Var_global t x)
   ∧
-  (compile_exp exh (Fun _ x e) =
-   Fun x (compile_exp exh e))
+  (compile_exp exh (Fun t x e) =
+   Fun t x (compile_exp exh e))
   ∧
-  (compile_exp exh (App _ op es) =
-   App op (compile_exps exh es))
+  (compile_exp exh (App t op es) =
+   App t op (compile_exps exh es))
   ∧
   (compile_exp exh (Mat t e pes) =
-   Mat (compile_exp exh e)
+   Mat t (compile_exp exh e)
      (compile_pes exh (add_default t F (exhaustive_match exh (MAP FST pes)) pes)))
   ∧
-  (compile_exp exh (Let _ x e1 e2) =
-   Let x (compile_exp exh e1) (compile_exp exh e2))
+  (compile_exp exh (Let t x e1 e2) =
+   Let t x (compile_exp exh e1) (compile_exp exh e2))
   ∧
-  (compile_exp exh (Letrec _ funs e) =
-   Letrec (compile_funs exh funs)
+  (compile_exp exh (Letrec t funs e) =
+   Letrec t (compile_funs exh funs)
      (compile_exp exh e))
   ∧
-  (compile_exp exh (Extend_global _ n) =
-   Extend_global n)
+  (compile_exp exh (Extend_global t n) =
+   Extend_global t n)
   ∧
   (compile_exps exh [] = [])
   ∧

--- a/compiler/backend/exhLangScript.sml
+++ b/compiler/backend/exhLangScript.sml
@@ -17,18 +17,18 @@ val _ = Datatype`
 
 val _ = Datatype`
   exp =
-   | Raise exp
-   | Handle exp ((pat # exp) list)
-   | Lit lit
-   | Con num (exp list)
-   | Var_local varN
-   | Var_global num
-   | Fun varN exp
-   | App op (exp list)
-   | Mat exp ((pat # exp) list)
-   | Let (varN option) exp exp
-   | Letrec ((varN # varN # exp) list) exp
-   | Extend_global num`;
+   | Raise tra exp
+   | Handle tra exp ((pat # exp) list)
+   | Lit tra lit
+   | Con tra num (exp list)
+   | Var_local tra varN
+   | Var_global tra num
+   | Fun tra varN exp
+   | App tra op (exp list)
+   | Mat tra exp ((pat # exp) list)
+   | Let tra (varN option) exp exp
+   | Letrec tra ((varN # varN # exp) list) exp
+   | Extend_global tra num`;
 
 val exp_size_def = definition"exp_size_def";
 

--- a/compiler/backend/exh_reorderScript.sml
+++ b/compiler/backend/exh_reorderScript.sml
@@ -60,21 +60,23 @@ const_cons_fst [
 
 val compile_def = tDefine "compile" `
     (compile [] = []) /\
-    (compile [Raise e] = [Raise (HD (compile [e]))]) /\
-    (compile [Handle e pes] =  [Handle (HD (compile [e])) (MAP (λ(p,e). (p,HD (compile [e]))) (const_cons_fst pes))]) /\
-    (compile [Lit l] = [Lit l]) /\
-    (compile [Con n es] = [Con n (compile es)] ) /\
-    (compile [Var_local v] = [Var_local v]) /\
-    (compile [Var_global n] = [Var_global n]) /\
-    (compile [Fun v e] = [Fun v (HD (compile [e]))]) /\
-    (compile [App op es] = [App op (compile es)]) /\
-    (compile [Mat e pes] =  [Mat (HD (compile [e])) (MAP (λ(p,e). (p,HD (compile [e]))) (const_cons_fst pes))]) /\
-    (compile [Let vo e1 e2] = [Let vo (HD (compile [e1])) (HD (compile [e2]))]) /\
-    (compile [Letrec funs e] =
-        [Letrec (MAP (\(a, b, e). (a,b, HD (compile [e]))) funs) (HD (compile [e]))]) /\
-    (compile [Extend_global n] = [Extend_global n]) /\
+    (compile [Raise t e] = [Raise t (HD (compile [e]))]) /\
+    (compile [Handle t e pes] =  [Handle t (HD (compile [e])) (MAP (λ(p,e). (p,HD (compile [e]))) (const_cons_fst pes))]) /\
+    (compile [Lit t l] = [Lit t l]) /\
+    (compile [Con t n es] = [Con t n (compile es)] ) /\
+    (compile [Var_local t v] = [Var_local t v]) /\
+    (compile [Var_global t n] = [Var_global t n]) /\
+    (compile [Fun t v e] = [Fun t v (HD (compile [e]))]) /\
+    (compile [App t op es] = [App t op (compile es)]) /\
+    (compile [Mat t e pes] =  [Mat t (HD (compile [e])) (MAP (λ(p,e). (p,HD (compile [e]))) (const_cons_fst pes))]) /\
+    (compile [Let t vo e1 e2] = [Let t vo (HD (compile [e1])) (HD (compile [e2]))]) /\
+    (compile [Letrec t funs e] =
+        [Letrec t (MAP (\(a, b, e). (a,b, HD (compile [e]))) funs) (HD (compile [e]))]) /\
+    (compile [Extend_global t n] = [Extend_global t n]) /\
     (compile (x::y::xs) = compile [x] ++ compile (y::xs))`
-(
+    cheat;
+(*(TODO: Update proof to be valid/consistent with the introduced traces 
+*
   WF_REL_TAC `measure exp6_size`
   \\ simp []
   \\ conj_tac
@@ -94,7 +96,7 @@ val compile_def = tDefine "compile" `
      \\ rw [exp_size_def]
      \\ res_tac \\ rw []
   )
-)
+)*)
 
 val compile_ind = theorem"compile_ind";
 

--- a/compiler/backend/exh_to_patScript.sml
+++ b/compiler/backend/exh_to_patScript.sml
@@ -6,7 +6,6 @@ val _ = patternMatchesLib.ENABLE_PMATCH_CASES();
 
 val Bool_def = Define `
   Bool b = Con (if b then true_tag else false_tag) []`;
-
 val Bool_eqns = save_thm("Bool_eqns[simp]",
   [``Bool T``,``Bool F``]
   |> List.map (SIMP_CONV(std_ss)[Bool_def])
@@ -261,40 +260,40 @@ val _ = tDefine"compile_row"`
 (* translate under a context of bound variables *)
 (* compile_pes assumes the value being matched is most recently bound *)
 val compile_exp_def = tDefine"compile_exp"`
-  (compile_exp bvs (Raise e) = Raise (compile_exp bvs e))
+  (compile_exp bvs (Raise t e) = Raise (compile_exp bvs e))
   ∧
-  (compile_exp bvs (Handle e1 pes) =
+  (compile_exp bvs (Handle t e1 pes) =
    Handle (compile_exp bvs e1) (compile_pes (NONE::bvs) pes))
   ∧
-  (compile_exp _ (Lit l) = Lit l)
+  (compile_exp _ (Lit t l) = Lit l)
   ∧
-  (compile_exp bvs (Con tag es) = Con tag (compile_exps bvs es))
+  (compile_exp bvs (Con t tag es) = Con tag (compile_exps bvs es))
   ∧
-  (compile_exp bvs (Var_local x) =
+  (compile_exp bvs (Var_local t x) =
    (dtcase find_index (SOME x) bvs 0 of
     | SOME k => Var_local k
     | NONE => Lit (IntLit 0) (* should not happen *)))
   ∧
-  (compile_exp _ (Var_global n) = Var_global n)
+  (compile_exp _ (Var_global t n) = Var_global n)
   ∧
-  (compile_exp bvs (Fun x e) = Fun (compile_exp (SOME x::bvs) e))
+  (compile_exp bvs (Fun t x e) = Fun (compile_exp (SOME x::bvs) e))
   ∧
-  (compile_exp bvs (App op es) = App (Op op) (compile_exps bvs es))
+  (compile_exp bvs (App t op es) = App (Op op) (compile_exps bvs es))
   ∧
-  (compile_exp bvs (Mat e pes) =
+  (compile_exp bvs (Mat t e pes) =
    sLet (compile_exp bvs e) (compile_pes (NONE::bvs) pes))
   ∧
-  (compile_exp bvs (Let (SOME x) e1 e2) =
+  (compile_exp bvs (Let t (SOME x) e1 e2) =
    sLet (compile_exp bvs e1) (compile_exp (SOME x::bvs) e2))
   ∧
-  (compile_exp bvs (Let NONE e1 e2) =
+  (compile_exp bvs (Let t NONE e1 e2) =
    Seq (compile_exp bvs e1) (compile_exp bvs e2))
   ∧
-  (compile_exp bvs (Letrec funs e) =
+  (compile_exp bvs (Letrec t funs e) =
    let bvs = (MAP (SOME o FST) funs) ++ bvs in
    Letrec (compile_funs bvs funs) (compile_exp bvs e))
   ∧
-  (compile_exp _ (Extend_global n) = Extend_global n)
+  (compile_exp _ (Extend_global t n) = Extend_global n)
   ∧
   (compile_exps _ [] = [])
   ∧


### PR DESCRIPTION
- Introduced traces in exhLang-constructors. 
- dec_to_exh should now pass traces on. 
- exh_reorder is updated to match the updated constructors in exhLang. Note that the compile-function no longer is proven but uses cheat.
- exh_tp_pat, added traces to left-side pattern-match to be in line with the updated exhLang-constructors.