### PR TITLE
Update `word_size_to_json`

### DIFF
--- a/compiler/backend/presLangScript.sml
+++ b/compiler/backend/presLangScript.sml
@@ -214,9 +214,9 @@ val trace_to_json_def = Define`
   (trace_to_json None = Null)`;
 
 val word_size_to_json_def = Define`
-  (word_size_to_json W8 = String "W8")
+  (word_size_to_json W8 = new_obj "W8" [])
   /\
-  (word_size_to_json W64 = String "W64")`;
+  (word_size_to_json W64 = new_obj "W64" [])`;
 
 val opn_to_json_def = Define`
   (opn_to_json Plus = new_obj "Plus" [])


### PR DESCRIPTION
This should have been in #15, but I forgot about it.

Continue updating the `_to_json` functions to be consistent with the "one object per constructor" approach.