### PR TITLE
Split traces properly, so that every expression has a unique trace

### DIFF
--- a/compiler/backend/exh_to_patScript.sml
+++ b/compiler/backend/exh_to_patScript.sml
@@ -15,13 +15,13 @@ val cons_bool_def = Define `
   cons_bool t b = Con t (if b then true_tag else false_tag) []`;
 
 val sIf_def = Define `
-  sIf t e1 e2 e3 =
+  sIf tra e1 e2 e3 =
   if e2 = Bool T ∧ e3 = Bool F
     then e1
   else
     (dtcase e1 of
      | Con _ t [] => if t = true_tag then e2 else e3
-     | _ => If t e1 e2 e3)`;
+     | _ => If tra e1 e2 e3)`;
 
 val sIf_pmatch = Q.store_thm("sIf_pmatch",`!e1 e2 e3.
   sIf t e1 e2 e3 =

--- a/compiler/backend/exh_to_patScript.sml
+++ b/compiler/backend/exh_to_patScript.sml
@@ -3,8 +3,7 @@ open backend_commonTheory
 
 val _ = new_theory"exh_to_pat"
 val _ = patternMatchesLib.ENABLE_PMATCH_CASES();
-(*TODO: Verify that Empty is fine for Con here (should be since the con is never
-* used but only there to determine true false, which the trace shouldnt affect *)
+
 val Bool_def = Define `
   Bool b = Con Empty (if b then true_tag else false_tag) []`;
 val Bool_eqns = save_thm("Bool_eqns[simp]",
@@ -12,14 +11,17 @@ val Bool_eqns = save_thm("Bool_eqns[simp]",
   |> List.map (SIMP_CONV(std_ss)[Bool_def])
   |> LIST_CONJ)
 
+val cons_bool_def = Define `
+  cons_bool t b = Con t (if b then true_tag else false_tag) []`;
+
 val sIf_def = Define `
-  sIf tra e1 e2 e3 =
+  sIf t e1 e2 e3 =
   if e2 = Bool T ∧ e3 = Bool F
     then e1
   else
     (dtcase e1 of
      | Con _ t [] => if t = true_tag then e2 else e3
-     | _ => If tra e1 e2 e3)`;
+     | _ => If t e1 e2 e3)`;
 
 val sIf_pmatch = Q.store_thm("sIf_pmatch",`!e1 e2 e3.
   sIf t e1 e2 e3 =
@@ -201,8 +203,8 @@ val _ = Define`
 (* return an expression that evaluates to whether the pattern matches the most
  * recently bound variable *)
 val _ = tDefine"compile_pat"`
-  (compile_pat _ (Pvar _) =
-   Bool T)
+  (compile_pat t (Pvar _) =
+   cons_bool t T)
   ∧
   (compile_pat t (Plit l) =
    App (mk_cons t 1) (Op (Op Equality)) [Var_local (mk_cons t 2) 0; Lit (mk_cons t 3) l])
@@ -212,7 +214,8 @@ val _ = tDefine"compile_pat"`
   ∧
   (compile_pat t (Pcon tag ps) =
    sIf (mk_cons t 1) (App (mk_cons t 2) (Tag_eq tag (LENGTH ps)) [Var_local (mk_cons t 3) 0])
-     (Let_Els (mk_cons t 4) 0 (LENGTH ps) (compile_pats (mk_cons t 5) 0 ps)) (Bool F))
+     (Let_Els (mk_cons t 4) 0 (LENGTH ps) (compile_pats (mk_cons t 5) 0 ps))
+     (cons_bool (mk_cons t 6) F))
   ∧
   (compile_pat t (Pref p) =
    sLet (mk_cons t 1) (App (mk_cons t 2) (Op (Op Opderef)) [Var_local (mk_cons t 3) 0])
@@ -220,11 +223,11 @@ val _ = tDefine"compile_pat"`
   ∧
 (* return an expression that evaluates to whether all the m patterns match the
  * m most recently bound variables; n counts 0..m *)
-  (compile_pats _ _ [] = Bool T)
+  (compile_pats t _ [] = cons_bool t T)
   ∧
   (compile_pats t n (p::ps) =
    sIf (mk_cons t 1) (sLet (mk_cons t 2) (Var_local (mk_cons t 3) n)
-   (compile_pat (mk_cons t 4) p)) (compile_pats (mk_cons t 5) (n+1) ps) (Bool F))`
+   (compile_pat (mk_cons t 4) p)) (compile_pats (mk_cons t 5) (n+1) ps) (cons_bool (mk_cons t 6) F))`
   cheat;
   (*(WF_REL_TAC `inv_image $< (\x. dtcase x of INL p => pat_size p
                                          | INR (n,ps) => pat1_size ps)`);*)

--- a/compiler/backend/source_to_modScript.sml
+++ b/compiler/backend/source_to_modScript.sml
@@ -100,6 +100,9 @@ val compile_exp_def = tDefine"compile_exp"`
     let (t1, t2) = (mk_cons t 1, mk_cons t 2) in
       Let t1 (SOME x) (compile_exp t env e1) (compile_exp t (nsBind x (Var_local t2 x) env) e2))
   ∧
+  (compile_exp t env (Let NONE e1 e2) =
+    Let t NONE (compile_exp t env e1) (compile_exp t env e2))
+  ∧
   (compile_exp t env (Letrec funs e) =
     let fun_names = MAP FST funs in
     let new_env = nsBindList (MAP (\x. (x, Var_local t x)) fun_names) env in

--- a/compiler/backend/source_to_modScript.sml
+++ b/compiler/backend/source_to_modScript.sml
@@ -45,8 +45,8 @@ val pat_tups_def = Define`
   (pat_tups t [] = [])
   /\
   (pat_tups t (x::xs) =
-    let t = mk_cons t ((LENGTH xs) + 1) in
-      (x, Var_local t x)::pat_tups t xs)`;
+    let t' = mk_cons t ((LENGTH xs) + 1) in
+      (x, Var_local t' x)::pat_tups t xs)`;
 
 (* The traces are passed along without being split for most expressions, since we
 * expect Lannots to appear around every expression. *)

--- a/compiler/backend/source_to_modScript.sml
+++ b/compiler/backend/source_to_modScript.sml
@@ -1,5 +1,4 @@
 open preamble astTheory terminationTheory modLangTheory;
-open jsonTheory;
 
 val _ = numLib.prefer_num();
 
@@ -15,12 +14,11 @@ val _ = new_theory"source_to_mod";
  * Closures rather than Recclosures.
  *)
 
- (*
-  * EXPLORER: The `t` parameter is the position information ("t" for "trace").
-  *)
+(* The traces start at 2 because this expression is called only from within
+ * compile_exp, where `mk_cons t 1` has been used. *)
 val Bool_def = Define `
  Bool t b =
-  let (t1, t2, t3) = (mk_cons t 1, mk_cons t 2, mk_cons t 3) in
+  let (t1, t2, t3) = (mk_cons t 2, mk_cons t 3, mk_cons t 4) in
    (App t1 (Opb (if b then Leq else Lt)) [Lit t2 (IntLit 0); Lit t3 (IntLit 0)])`;
 
 (*
@@ -74,17 +72,17 @@ val compile_exp_def = tDefine"compile_exp"`
     App t op (compile_exps t env es))
   ∧
   (compile_exp t env (Log lop e1 e2) =
-    let (t1, t2) = (mk_cons t 1, mk_cons t 2) in
+    let t' = mk_cons t 1 in
       case lop of
       | And =>
-        If t1
+        If t'
            (compile_exp t env e1)
            (compile_exp t env e2)
-           (Bool t2 F)
+           (Bool t F)
       | Or =>
-        If t1
+        If t'
            (compile_exp t env e1)
-           (Bool t2 T)
+           (Bool t T)
            (compile_exp t env e2))
   ∧
   (compile_exp t env (If e1 e2 e3) =

--- a/compiler/backend/source_to_modScript.sml
+++ b/compiler/backend/source_to_modScript.sml
@@ -68,7 +68,7 @@ val compile_exp_def = tDefine"compile_exp"`
   ∧
   (compile_exp t env (Fun x e) =
     let (t1, t2) = (mk_cons t 1, mk_cons t 2) in
-      Fun t1 x (compile_exp t (nsBind x (Var_local t1 x) env) e))
+      Fun t1 x (compile_exp t (nsBind x (Var_local t2 x) env) e))
   ∧
   (compile_exp t env (App op es) =
     App t op (compile_exps t env es))


### PR DESCRIPTION
At some points in `source_to_mod` and `exh_to_pat` we created many expressions with the same trace. This pull request fixes that.