### PR TITLE
Renaming intermediate languages

### DIFF
--- a/compiler/backend/backendScript.sml
+++ b/compiler/backend/backendScript.sml
@@ -14,7 +14,7 @@ open preamble
      lab_to_targetTheory
 local open primTypesTheory in end
 open word_to_wordTheory
-open jsonTheory presLangTheory
+open jsonLangTheory presLangTheory
 
 val _ = new_theory"backend";
 

--- a/compiler/backend/displayLangScript.sml
+++ b/compiler/backend/displayLangScript.sml
@@ -1,11 +1,11 @@
 open preamble jsonLangTheory backend_commonTheory;
 
-val _ = new_theory"structuredLang";
+val _ = new_theory"displayLang";
 
 
-(* structuredLang is an intermediate language between presLang and json. The
+(* displayLang is an intermediate language between presLang and jsonLang. The
 * purpose of strucutredLang is to force each presLang expression into a unified
-* form, that is easily expressed by uniform json object that are either
+* form, that is easily expressed by uniform jsonLang object that are either
 *   a) Objects representing a tuple (Tuple)
 *   b) Objects representing a constructor with many arguments or (Item)
 *   c) Arrays (List)
@@ -18,7 +18,7 @@ val _ = Datatype`
 
 val sExp_size_def = fetch "-" "sExp_size_def";
 
-(* structured_to_json *)
+(* display_to_json *)
 val num_to_json_def = Define`
   num_to_json n = String (num_to_str n)`;
 
@@ -39,21 +39,21 @@ val MEM_sExp_size = store_thm("MEM_sExp_size",
   ``!es a. MEM a es ==> sExp_size a < sExp1_size es``,
   Induct \\ fs [] \\ rw [sExp_size_def] \\ fs [] \\ res_tac \\ fs []);
 
-(* Converts a structured expression to JSON *)
-val structured_to_json_def = tDefine"structured_to_json" `
-  (structured_to_json (Item tra name es) =
-    let es' = MAP structured_to_json es in
+(* Converts a display expression to JSON *)
+val display_to_json_def = tDefine"display_to_json" `
+  (display_to_json (Item tra name es) =
+    let es' = MAP display_to_json es in
     let props = [("name", String name); ("args", Array es')] in
     let props' = case tra of
                    | NONE => props
                    | SOME t => ("trace", trace_to_json t)::props in
       Object props')
    /\
-  (structured_to_json (Tuple es) =
-    let es' = MAP structured_to_json es in
+  (display_to_json (Tuple es) =
+    let es' = MAP display_to_json es in
       Object [("isTuple", Bool T); ("elements", Array es')])
   /\
-   (structured_to_json (List es) = Array (MAP structured_to_json es))`
+   (display_to_json (List es) = Array (MAP display_to_json es))`
   (WF_REL_TAC `measure sExp_size` \\ rw []
    \\ imp_res_tac MEM_sExp_size \\ fs []);
 

--- a/compiler/backend/jsonLangScript.sml
+++ b/compiler/backend/jsonLangScript.sml
@@ -1,6 +1,6 @@
 open preamble
 
-val _ = new_theory"json";
+val _ = new_theory"jsonLang";
 
 (*
 * This module contains a data type for representing JSON objects, and related

--- a/compiler/backend/presLangScript.sml
+++ b/compiler/backend/presLangScript.sml
@@ -1,6 +1,6 @@
 open preamble astTheory;
 open conLangTheory modLangTheory exhLangTheory patLangTheory closLangTheory
-     structuredLangTheory;
+     displayLangTheory;
 
 val _ = new_theory"presLang";
 
@@ -10,13 +10,12 @@ val _ = new_theory"presLang";
 * constructors for patLang differ a bit since we don't want to present
 * information using de bruijn indices but rather variable names.
 *
-* The purpose of presLang is to be an intermediate representation between an intermediate language of the
-* compiler and the structured language. By translating an intermediate language
-* to presLang, it can be given a structured representation by calling
-* pres_to_strucutred on the presLang representation. presLang has no semantics,
-* as it is never evaluated, and may therefore mix operators, declarations,
-* patterns and expressions.
-*
+* The purpose of presLang is to be an intermediate representation between an
+* intermediate language of the compiler and the display language. By translating
+* an intermediate language to presLang, it can be given a display representation
+* by calling pres_to_display on the presLang representation. presLang has no
+* semantics, as it is never evaluated, and may therefore mix operators,
+* declarations, patterns and expressions.
 *)
 
 (* Special operator wrapper for presLang *)
@@ -432,148 +431,148 @@ val clos_to_pres_code_def = Define `
       (MAP (\(n,arity,body). (n,num_to_varn_list 0 arity,
          clos_to_pres arity body)) code_table)`
 
-(* Helpers for converting pres to structured. *)
+(* Helpers for converting pres to display. *)
 val empty_item_def = Define`
   empty_item name = Item NONE name []`;
 
-val string_to_structured_def = Define`
-  string_to_structured s = empty_item ("\"" ++ s ++ "\"")`;
+val string_to_display_def = Define`
+  string_to_display s = empty_item ("\"" ++ s ++ "\"")`;
 
-val num_to_structured_def = Define`
-  num_to_structured n = empty_item (num_to_str n)`;
+val num_to_display_def = Define`
+  num_to_display n = empty_item (num_to_str n)`;
 
-val word_size_to_structured_def = Define`
-  (word_size_to_structured W8 = empty_item "W8")
+val word_size_to_display_def = Define`
+  (word_size_to_display W8 = empty_item "W8")
   /\
-  (word_size_to_structured W64 = empty_item "W64")`;
+  (word_size_to_display W64 = empty_item "W64")`;
 
-val opn_to_structured_def = Define`
-  (opn_to_structured Plus = empty_item "Plus")
+val opn_to_display_def = Define`
+  (opn_to_display Plus = empty_item "Plus")
   /\
-  (opn_to_structured Minus = empty_item "Minus")
+  (opn_to_display Minus = empty_item "Minus")
   /\
-  (opn_to_structured Times = empty_item "Times")
+  (opn_to_display Times = empty_item "Times")
   /\
-  (opn_to_structured Divide = empty_item "Divide")
+  (opn_to_display Divide = empty_item "Divide")
   /\
-  (opn_to_structured Modulo = empty_item "Modulo")`;
+  (opn_to_display Modulo = empty_item "Modulo")`;
 
-val opb_to_structured_def = Define`
-  (opb_to_structured Lt = empty_item "Lt")
+val opb_to_display_def = Define`
+  (opb_to_display Lt = empty_item "Lt")
   /\
-  (opb_to_structured Gt = empty_item "Gt")
+  (opb_to_display Gt = empty_item "Gt")
   /\
-  (opb_to_structured Leq = empty_item "Leq")
+  (opb_to_display Leq = empty_item "Leq")
   /\
-  (opb_to_structured Geq = empty_item "Geq")`;
+  (opb_to_display Geq = empty_item "Geq")`;
 
-val opw_to_structured_def = Define`
-  (opw_to_structured Andw = empty_item "Andw")
+val opw_to_display_def = Define`
+  (opw_to_display Andw = empty_item "Andw")
   /\
-  (opw_to_structured Orw = empty_item "Orw")
+  (opw_to_display Orw = empty_item "Orw")
   /\
-  (opw_to_structured Xor = empty_item "Xor")
+  (opw_to_display Xor = empty_item "Xor")
   /\
-  (opw_to_structured Add = empty_item "Add")
+  (opw_to_display Add = empty_item "Add")
   /\
-  (opw_to_structured Sub = empty_item "Sub")`;
+  (opw_to_display Sub = empty_item "Sub")`;
 
-val shift_to_structured_def = Define`
-  (shift_to_structured Lsl = empty_item "Lsl")
+val shift_to_display_def = Define`
+  (shift_to_display Lsl = empty_item "Lsl")
   /\
-  (shift_to_structured Lsr = empty_item "Lsr")
+  (shift_to_display Lsr = empty_item "Lsr")
   /\
-  (shift_to_structured Asr = empty_item "Asr")
+  (shift_to_display Asr = empty_item "Asr")
   /\
-  (shift_to_structured Ror = empty_item "Ror")`;
+  (shift_to_display Ror = empty_item "Ror")`;
 
-val op_to_structured_def = Define`
-  (op_to_structured (Patlang_op (Tag_eq n1 n2)) =
-    Item NONE "Tag_eq" [(num_to_structured n1);(num_to_structured n2)])
+val op_to_display_def = Define`
+  (op_to_display (Patlang_op (Tag_eq n1 n2)) =
+    Item NONE "Tag_eq" [(num_to_display n1);(num_to_display n2)])
   /\
-  (op_to_structured (Patlang_op (El num)) = Item NONE "El" [num_to_structured num])
+  (op_to_display (Patlang_op (El num)) = Item NONE "El" [num_to_display num])
   /\
-  (op_to_structured (Patlang_op (Op op)) = op_to_structured (Conlang_op op))
+  (op_to_display (Patlang_op (Op op)) = op_to_display (Conlang_op op))
   /\
-  (op_to_structured (Conlang_op (Init_global_var num)) =
-    Item NONE "Init_global_var" [num_to_structured num])
+  (op_to_display (Conlang_op (Init_global_var num)) =
+    Item NONE "Init_global_var" [num_to_display num])
   /\
-  (op_to_structured (Conlang_op (Op astop)) = Item NONE "Op" [op_to_structured (Ast_op (astop))])
+  (op_to_display (Conlang_op (Op astop)) = Item NONE "Op" [op_to_display (Ast_op (astop))])
   /\
-  (op_to_structured (Ast_op (Opn opn)) = Item NONE "Opn" [opn_to_structured opn])
+  (op_to_display (Ast_op (Opn opn)) = Item NONE "Opn" [opn_to_display opn])
   /\
-  (op_to_structured (Ast_op (Opb opb)) = Item NONE "Opb" [opb_to_structured opb])
+  (op_to_display (Ast_op (Opb opb)) = Item NONE "Opb" [opb_to_display opb])
   /\
-  (op_to_structured (Ast_op (Opw word_size opw)) =
-    Item NONE "Opw" [ word_size_to_structured word_size; opw_to_structured opw ])
+  (op_to_display (Ast_op (Opw word_size opw)) =
+    Item NONE "Opw" [ word_size_to_display word_size; opw_to_display opw ])
   /\
-  (op_to_structured (Ast_op (Shift word_size shift num)) =
+  (op_to_display (Ast_op (Shift word_size shift num)) =
     Item NONE "Shift" [
-      word_size_to_structured word_size;
-      shift_to_structured shift;
-      num_to_structured num
+      word_size_to_display word_size;
+      shift_to_display shift;
+      num_to_display num
   ])
   /\
-  (op_to_structured (Ast_op Equality) = empty_item "Equality")
+  (op_to_display (Ast_op Equality) = empty_item "Equality")
   /\
-  (op_to_structured (Ast_op Opapp) = empty_item "Opapp")
+  (op_to_display (Ast_op Opapp) = empty_item "Opapp")
   /\
-  (op_to_structured (Ast_op Opassign) = empty_item "Opassign")
+  (op_to_display (Ast_op Opassign) = empty_item "Opassign")
   /\
-  (op_to_structured (Ast_op Oprep) = empty_item "Oprep")
+  (op_to_display (Ast_op Oprep) = empty_item "Oprep")
   /\
-  (op_to_structured (Ast_op Opderep) = empty_item "Opderep")
+  (op_to_display (Ast_op Opderep) = empty_item "Opderep")
   /\
-  (op_to_structured (Ast_op Aw8alloc) = empty_item "Aw8alloc")
+  (op_to_display (Ast_op Aw8alloc) = empty_item "Aw8alloc")
   /\
-  (op_to_structured (Ast_op Aw8sub) = empty_item "Aw8sub")
+  (op_to_display (Ast_op Aw8sub) = empty_item "Aw8sub")
   /\
-  (op_to_structured (Ast_op Aw8length) = empty_item "Aw8length")
+  (op_to_display (Ast_op Aw8length) = empty_item "Aw8length")
   /\
-  (op_to_structured (Ast_op Aw8update) = empty_item "Aw8update")
+  (op_to_display (Ast_op Aw8update) = empty_item "Aw8update")
   /\
-  (op_to_structured (Ast_op (WordFromInt word_size)) =
-    Item NONE "WordFromInt" [word_size_to_structured word_size])
+  (op_to_display (Ast_op (WordFromInt word_size)) =
+    Item NONE "WordFromInt" [word_size_to_display word_size])
   /\
-  (op_to_structured (Ast_op (WordToInt word_size)) =
-    Item NONE "WordToInt" [word_size_to_structured word_size])
+  (op_to_display (Ast_op (WordToInt word_size)) =
+    Item NONE "WordToInt" [word_size_to_display word_size])
   /\
-  (op_to_structured (Ast_op Ord) = empty_item "Ord")
+  (op_to_display (Ast_op Ord) = empty_item "Ord")
   /\
-  (op_to_structured (Ast_op Chr) = empty_item "Chr")
+  (op_to_display (Ast_op Chr) = empty_item "Chr")
   /\
-  (op_to_structured (Ast_op (Chopb opb)) =
-    Item NONE "Chopb" [opb_to_structured opb])
+  (op_to_display (Ast_op (Chopb opb)) =
+    Item NONE "Chopb" [opb_to_display opb])
   /\
-  (op_to_structured (Ast_op Implode) = empty_item "Implode")
+  (op_to_display (Ast_op Implode) = empty_item "Implode")
   /\
-  (op_to_structured (Ast_op Strsub) = empty_item "Strsub")
+  (op_to_display (Ast_op Strsub) = empty_item "Strsub")
   /\
-  (op_to_structured (Ast_op Strlen) = empty_item "Strlen")
+  (op_to_display (Ast_op Strlen) = empty_item "Strlen")
   /\
-  (op_to_structured (Ast_op VfromList) = empty_item "VfromList")
+  (op_to_display (Ast_op VfromList) = empty_item "VfromList")
   /\
-  (op_to_structured (Ast_op Vsub) = empty_item "Vsub")
+  (op_to_display (Ast_op Vsub) = empty_item "Vsub")
   /\
-  (op_to_structured (Ast_op Vlength) = empty_item "Vlength")
+  (op_to_display (Ast_op Vlength) = empty_item "Vlength")
   /\
-  (op_to_structured (Ast_op Aalloc) = empty_item "Aalloc")
+  (op_to_display (Ast_op Aalloc) = empty_item "Aalloc")
   /\
-  (op_to_structured (Ast_op Asub) = empty_item "Asub")
+  (op_to_display (Ast_op Asub) = empty_item "Asub")
   /\
-  (op_to_structured (Ast_op Alength) = empty_item "Alength")
+  (op_to_display (Ast_op Alength) = empty_item "Alength")
   /\
-  (op_to_structured (Ast_op Aupdate) = empty_item "Aupdate")
+  (op_to_display (Ast_op Aupdate) = empty_item "Aupdate")
   /\
-  (op_to_structured (Ast_op (FFI str)) =
-    Item NONE "FFI" [string_to_structured str])`;
+  (op_to_display (Ast_op (FFI str)) =
+    Item NONE "FFI" [string_to_display str])`;
 
-val lop_to_structured_def = Define`
-  (lop_to_structured ast$And = empty_item "And")
+val lop_to_display_def = Define`
+  (lop_to_display ast$And = empty_item "And")
   /\
-  (lop_to_structured Or = empty_item "Or")
+  (lop_to_display Or = empty_item "Or")
   /\
-  (lop_to_structured _ = empty_item "Unknown")`;
+  (lop_to_display _ = empty_item "Unknown")`;
 
 val num_to_hex_digit_def = Define `
   num_to_hex_digit n =
@@ -588,100 +587,100 @@ val num_to_hex_def = Define `
 val word_to_hex_string_def = Define `
   word_to_hex_string w = "0x" ++ num_to_hex (w2n (w:'a word))`;
 
-val lit_to_structured_def = Define`
-  (lit_to_structured (IntLit i) =
+val lit_to_display_def = Define`
+  (lit_to_display (IntLit i) =
     Item NONE "IntLit" [empty_item (int_to_str i)])
   /\
-  (lit_to_structured (Char c) =
+  (lit_to_display (Char c) =
     Item NONE "Char" [empty_item ("#\"" ++ [c] ++ "\"")])
   /\
-  (lit_to_structured (StrLit s) =
-    Item NONE "StrLit" [string_to_structured s])
+  (lit_to_display (StrLit s) =
+    Item NONE "StrLit" [string_to_display s])
   /\
-  (lit_to_structured (Word8 w) =
+  (lit_to_display (Word8 w) =
     Item NONE "Word8" [empty_item (word_to_hex_string w)])
   /\
-  (lit_to_structured (Word64 w) =
+  (lit_to_display (Word64 w) =
     Item NONE "Word64" [empty_item (word_to_hex_string w)])`;
 
-val list_to_structured_def = Define`
-  (list_to_structured f xs = List (MAP f xs))`
+val list_to_display_def = Define`
+  (list_to_display f xs = List (MAP f xs))`
 
-val option_to_structured_def = Define`
-  (option_to_structured f opt = case opt of
+val option_to_display_def = Define`
+  (option_to_display f opt = case opt of
                       | NONE => empty_item "NONE"
                       | SOME opt' => Item NONE "SOME" [f opt'])`
 
-val option_string_to_structured_def = Define`
-  (option_string_to_structured opt = case opt of
+val option_string_to_display_def = Define`
+  (option_string_to_display opt = case opt of
                       | NONE => empty_item "NONE"
-                      | SOME opt' => Item NONE "SOME" [string_to_structured opt'])`
+                      | SOME opt' => Item NONE "SOME" [string_to_display opt'])`
 
-val id_to_structured_def = Define`
-  (id_to_structured (Long name i) = Item NONE "Long" [id_to_structured i; string_to_structured name])
+val id_to_display_def = Define`
+  (id_to_display (Long name i) = Item NONE "Long" [id_to_display i; string_to_display name])
   /\
-  (id_to_structured (Short name) = Item NONE "Short" [string_to_structured name])`;
+  (id_to_display (Short name) = Item NONE "Short" [string_to_display name])`;
 
-val tctor_to_structured_def = Define`
-  (tctor_to_structured (ast$TC_name ids) =
-    let ids' = id_to_structured ids in
+val tctor_to_display_def = Define`
+  (tctor_to_display (ast$TC_name ids) =
+    let ids' = id_to_display ids in
       Item NONE "TC_name" [ids'])
   /\
-  (tctor_to_structured TC_int = empty_item "TC_int")
+  (tctor_to_display TC_int = empty_item "TC_int")
   /\
-  (tctor_to_structured TC_char = empty_item "TC_char")
+  (tctor_to_display TC_char = empty_item "TC_char")
   /\
-  (tctor_to_structured TC_string = empty_item "TC_string")
+  (tctor_to_display TC_string = empty_item "TC_string")
   /\
-  (tctor_to_structured TC_ref = empty_item "TC_ref")
+  (tctor_to_display TC_ref = empty_item "TC_ref")
   /\
-  (tctor_to_structured TC_word8 = empty_item "TC_word8")
+  (tctor_to_display TC_word8 = empty_item "TC_word8")
   /\
-  (tctor_to_structured TC_word64 = empty_item "TC_word64")
+  (tctor_to_display TC_word64 = empty_item "TC_word64")
   /\
-  (tctor_to_structured TC_word8array = empty_item "TC_word8array")
+  (tctor_to_display TC_word8array = empty_item "TC_word8array")
   /\
-  (tctor_to_structured TC_fn = empty_item "TC_fn")
+  (tctor_to_display TC_fn = empty_item "TC_fn")
   /\
-  (tctor_to_structured TC_tup = empty_item "TC_tup")
+  (tctor_to_display TC_tup = empty_item "TC_tup")
   /\
-  (tctor_to_structured TC_exn = empty_item "TC_exp")
+  (tctor_to_display TC_exn = empty_item "TC_exp")
   /\
-  (tctor_to_structured TC_vector = empty_item "TC_vector")
+  (tctor_to_display TC_vector = empty_item "TC_vector")
   /\
-  (tctor_to_structured TC_array = empty_item "TC_array")`
+  (tctor_to_display TC_array = empty_item "TC_array")`
 
 val MEM_t_size = prove(
   ``!ts t. MEM t ts ==> t_size t < t1_size ts``,
   Induct \\ fs [t_size_def] \\ rw [] \\ res_tac \\ fs []);
 
-val t_to_structured_def = tDefine "t_to_structured" `
-  (t_to_structured (Tvar tvarN) = Item NONE "Tvar" [string_to_structured tvarN])
+val t_to_display_def = tDefine "t_to_display" `
+  (t_to_display (Tvar tvarN) = Item NONE "Tvar" [string_to_display tvarN])
   /\
-  (t_to_structured (Tvar_db n) = Item NONE "Tvar_db" [num_to_structured n])
+  (t_to_display (Tvar_db n) = Item NONE "Tvar_db" [num_to_display n])
   /\
-  (t_to_structured (Tapp ts tctor) = Item NONE "Tapp" [List (MAP t_to_structured ts); tctor_to_structured tctor])`
+  (t_to_display (Tapp ts tctor) = Item NONE "Tapp" [List (MAP t_to_display ts); tctor_to_display tctor])`
   (WF_REL_TAC `measure t_size` \\ rw []
    \\ imp_res_tac MEM_t_size \\ fs []);
 
-val tid_or_exn_to_structured_def = Define`
-  tid_or_exn_to_structured te =
+val tid_or_exn_to_display_def = Define`
+  tid_or_exn_to_display te =
    let (name, id) =
      case te of
        | TypeId id => ("TypeId", id)
        | TypeExn id => ("TypeExn", id) in
-     Item NONE name [id_to_structured id]`;
+     Item NONE name [id_to_display id]`;
 
-val conf_to_structured_def = Define`
-  conf_to_structured con =
+val conf_to_display_def = Define`
+  conf_to_display con =
     let none = empty_item "NONE" in
       case con of
          | Modlang_con NONE => none
          | Conlang_con NONE => none
-         | Modlang_con (SOME id) => Item NONE "SOME" [id_to_structured id]
+         | Modlang_con (SOME id) => Item NONE "SOME" [id_to_display id]
          | Conlang_con (SOME (n,t)) =>
-            Item NONE "SOME" [Tuple [num_to_structured n; tid_or_exn_to_structured t]]
-         | Exhlang_con c => Item NONE "SOME" [num_to_structured c]`;
+            Item NONE "SOME" [Tuple [num_to_display n; tid_or_exn_to_display t]]
+         | Exhlang_con c => Item NONE "SOME" [num_to_display c]`;
 
 (* Takes a presLang$exp and produces jsonLang$obj that mimics its structure. *)
 
@@ -710,165 +709,165 @@ val MEM_varexpTup6_size = prove(
   ``!xs x z. MEM (x,z) xs ==> exp_size z < exp8_size xs``,
   Induct \\ fs [exp_size_def] \\ rw [] \\ res_tac \\ fs [exp_size_def]);
 
-val pres_to_structured_def = tDefine"pres_to_structured" `
+val pres_to_display_def = tDefine"pres_to_display" `
   (* Top level *)
-  (pres_to_structured (presLang$Prog tops) =
-    let tops' = List (MAP pres_to_structured tops) in
+  (pres_to_display (presLang$Prog tops) =
+    let tops' = List (MAP pres_to_display tops) in
       Item NONE "Prog" [tops'])
   /\
-  (pres_to_structured (Prompt modN decs) =
-    let decs' = List (MAP pres_to_structured decs) in
-    let modN' = option_string_to_structured modN in
+  (pres_to_display (Prompt modN decs) =
+    let decs' = List (MAP pres_to_display decs) in
+    let modN' = option_string_to_display modN in
       Item NONE "Prompt" [modN'; decs'])
   /\
-  (pres_to_structured (Dlet num exp) =
-      Item NONE "Dlet" [num_to_structured num; pres_to_structured exp])
+  (pres_to_display (Dlet num exp) =
+      Item NONE "Dlet" [num_to_display num; pres_to_display exp])
   /\
-  (pres_to_structured (Dletrec lst) =
+  (pres_to_display (Dletrec lst) =
     let fields =
-      List (MAP (\ (v1, v2, exp) . Tuple [string_to_structured v1; string_to_structured v2; pres_to_structured exp]) lst) in
+      List (MAP (\ (v1, v2, exp) . Tuple [string_to_display v1; string_to_display v2; pres_to_display exp]) lst) in
       Item NONE "Dletrec" [fields] )
   /\
-  (pres_to_structured (Dtype modNs) =
-    let modNs' = List (MAP string_to_structured modNs) in
+  (pres_to_display (Dtype modNs) =
+    let modNs' = List (MAP string_to_display modNs) in
       Item NONE "Dtype" [modNs'])
   /\
-  (pres_to_structured (Dexn modNs conN ts) =
-    let modNs' = List (MAP string_to_structured modNs) in
-    let ts' = List (MAP t_to_structured ts) in
-      Item NONE "Dexn" [modNs'; string_to_structured conN; ts'])
+  (pres_to_display (Dexn modNs conN ts) =
+    let modNs' = List (MAP string_to_display modNs) in
+    let ts' = List (MAP t_to_display ts) in
+      Item NONE "Dexn" [modNs'; string_to_display conN; ts'])
   /\
-  (pres_to_structured (Pvar varN) =
-      Item NONE "Pvar" [string_to_structured varN])
+  (pres_to_display (Pvar varN) =
+      Item NONE "Pvar" [string_to_display varN])
   /\
-  (pres_to_structured (Plit lit) =
-      Item NONE "Plit" [lit_to_structured lit])
+  (pres_to_display (Plit lit) =
+      Item NONE "Plit" [lit_to_display lit])
   /\
-  (pres_to_structured (Pcon conF exps) =
-    let exps' = List (MAP pres_to_structured exps) in
-      Item NONE "Pcon" [conf_to_structured conF; exps'])
+  (pres_to_display (Pcon conF exps) =
+    let exps' = List (MAP pres_to_display exps) in
+      Item NONE "Pcon" [conf_to_display conF; exps'])
   /\
-  (pres_to_structured (Pref exp) =
-      Item NONE "Pref" [pres_to_structured exp])
+  (pres_to_display (Pref exp) =
+      Item NONE "Pref" [pres_to_display exp])
   /\
-  (pres_to_structured (Ptannot exp t) =
-      Item NONE "Ptannot" [pres_to_structured exp; t_to_structured t])
+  (pres_to_display (Ptannot exp t) =
+      Item NONE "Ptannot" [pres_to_display exp; t_to_display t])
   /\
-  (pres_to_structured (Raise tra exp) =
-      Item (SOME tra) "Raise" [pres_to_structured exp])
+  (pres_to_display (Raise tra exp) =
+      Item (SOME tra) "Raise" [pres_to_display exp])
   /\
-  (pres_to_structured (Tick tra exp) =
-      Item (SOME tra) "Tick" [pres_to_structured exp])
+  (pres_to_display (Tick tra exp) =
+      Item (SOME tra) "Tick" [pres_to_display exp])
   /\
-  (pres_to_structured (Handle tra exp expsTup) =
-    let expsTup' = List (MAP (\(e1, e2) . Tuple [pres_to_structured e1; pres_to_structured e2]) expsTup) in
-      Item (SOME tra) "Handle" [pres_to_structured exp; expsTup'])
+  (pres_to_display (Handle tra exp expsTup) =
+    let expsTup' = List (MAP (\(e1, e2) . Tuple [pres_to_display e1; pres_to_display e2]) expsTup) in
+      Item (SOME tra) "Handle" [pres_to_display exp; expsTup'])
   /\
-  (pres_to_structured (Handle' tra exp varN exp2) =
-    Item (SOME tra) "Handle" [pres_to_structured exp;
-                              string_to_structured varN;
-                              pres_to_structured exp])
+  (pres_to_display (Handle' tra exp varN exp2) =
+    Item (SOME tra) "Handle" [pres_to_display exp;
+                              string_to_display varN;
+                              pres_to_display exp])
   /\
-  (pres_to_structured (Var tra varN) =
-      Item (SOME tra) "Var" [string_to_structured varN])
+  (pres_to_display (Var tra varN) =
+      Item (SOME tra) "Var" [string_to_display varN])
   /\
-  (pres_to_structured (Var_local tra varN) =
-      Item (SOME tra) "Var_local" [string_to_structured varN])
+  (pres_to_display (Var_local tra varN) =
+      Item (SOME tra) "Var_local" [string_to_display varN])
   /\
-  (pres_to_structured (Var_global tra num) =
-      Item (SOME tra) "Var_global" [num_to_structured num])
+  (pres_to_display (Var_global tra num) =
+      Item (SOME tra) "Var_global" [num_to_display num])
   /\
-  (pres_to_structured (Extend_global tra num) =
-      Item (SOME tra) "Extend_global" [num_to_structured num])
+  (pres_to_display (Extend_global tra num) =
+      Item (SOME tra) "Extend_global" [num_to_display num])
   /\
-  (pres_to_structured (Lit tra lit) =
-      Item (SOME tra) "Lit" [lit_to_structured lit])
+  (pres_to_display (Lit tra lit) =
+      Item (SOME tra) "Lit" [lit_to_display lit])
   /\
-  (pres_to_structured (Con tra conF exps) =
-    let exps' = List (MAP pres_to_structured exps) in
-      Item (SOME tra) "Pcon" [conf_to_structured conF; exps'])
+  (pres_to_display (Con tra conF exps) =
+    let exps' = List (MAP pres_to_display exps) in
+      Item (SOME tra) "Pcon" [conf_to_display conF; exps'])
   /\
-  (pres_to_structured (App tra op exps) =
-    let exps' = List (MAP pres_to_structured exps) in
-      Item (SOME tra) "App" [op_to_structured op; exps'])
+  (pres_to_display (App tra op exps) =
+    let exps' = List (MAP pres_to_display exps) in
+      Item (SOME tra) "App" [op_to_display op; exps'])
   /\
-  (pres_to_structured (Op tra op exps) =
-    let exps' = List (MAP pres_to_structured exps) in
-      Item (SOME tra) "Op" [op_to_structured op; exps'])
+  (pres_to_display (Op tra op exps) =
+    let exps' = List (MAP pres_to_display exps) in
+      Item (SOME tra) "Op" [op_to_display op; exps'])
   /\
-  (pres_to_structured (Fun tra varN exp) =
-      Item (SOME tra) "Fun" [string_to_structured varN; pres_to_structured exp])
+  (pres_to_display (Fun tra varN exp) =
+      Item (SOME tra) "Fun" [string_to_display varN; pres_to_display exp])
   /\
-  (pres_to_structured (Fn tra n0 n1 varN exp) =
+  (pres_to_display (Fn tra n0 n1 varN exp) =
       Item (SOME tra) "Fn"
-        [option_to_structured num_to_structured n0;
-         option_to_structured (list_to_structured num_to_structured) n1;
-         list_to_structured string_to_structured varN;
-         pres_to_structured exp])
+        [option_to_display num_to_display n0;
+         option_to_display (list_to_display num_to_display) n1;
+         list_to_display string_to_display varN;
+         pres_to_display exp])
   /\
-  (pres_to_structured (Log tra lop exp1 exp2) =
-      Item (SOME tra) "Log" [lop_to_structured lop; pres_to_structured exp1; pres_to_structured exp2])
+  (pres_to_display (Log tra lop exp1 exp2) =
+      Item (SOME tra) "Log" [lop_to_display lop; pres_to_display exp1; pres_to_display exp2])
   /\
-  (pres_to_structured (If tra exp1 exp2 exp3) =
-      Item (SOME tra) "If" [pres_to_structured exp1; pres_to_structured exp2; pres_to_structured exp3])
+  (pres_to_display (If tra exp1 exp2 exp3) =
+      Item (SOME tra) "If" [pres_to_display exp1; pres_to_display exp2; pres_to_display exp3])
   /\
-  (pres_to_structured (Mat tra exp expsTup) =
-    let expsTup' = List (MAP (\(e1, e2) . Tuple [pres_to_structured e1; pres_to_structured e2]) expsTup) in
-      Item (SOME tra) "Mat" [pres_to_structured exp; expsTup'])
+  (pres_to_display (Mat tra exp expsTup) =
+    let expsTup' = List (MAP (\(e1, e2) . Tuple [pres_to_display e1; pres_to_display e2]) expsTup) in
+      Item (SOME tra) "Mat" [pres_to_display exp; expsTup'])
   /\
-  (pres_to_structured (Let tra varN exp1 exp2) =
-    let varN' = option_string_to_structured varN in
-      Item (SOME tra) "Let" [varN'; pres_to_structured exp1; pres_to_structured exp2])
+  (pres_to_display (Let tra varN exp1 exp2) =
+    let varN' = option_string_to_display varN in
+      Item (SOME tra) "Let" [varN'; pres_to_display exp1; pres_to_display exp2])
   /\
-  (pres_to_structured (Letrec tra varexpTup exp) =
+  (pres_to_display (Letrec tra varexpTup exp) =
     let varexpTup' = List (MAP (\ (v1, v2, e) . Tuple [
-      string_to_structured v1;
-      string_to_structured v2;
-      pres_to_structured e
+      string_to_display v1;
+      string_to_display v2;
+      pres_to_display e
     ]) varexpTup) in
-      Item (SOME tra) "Letrec" [varexpTup'; pres_to_structured exp])
+      Item (SOME tra) "Letrec" [varexpTup'; pres_to_display exp])
   /\
-  (pres_to_structured (Letrec' tra n1 n2 varexpTup exp) =
+  (pres_to_display (Letrec' tra n1 n2 varexpTup exp) =
     let varexpTup' = List (MAP (\ (v1, args, e) . Tuple [
-      string_to_structured v1;
-      List (MAP string_to_structured args);
-      pres_to_structured e
+      string_to_display v1;
+      List (MAP string_to_display args);
+      pres_to_display e
     ]) varexpTup) in
       Item (SOME tra) "Letrec"
-        [option_to_structured num_to_structured n1;
-         option_to_structured (list_to_structured num_to_structured) n2;
+        [option_to_display num_to_display n1;
+         option_to_display (list_to_display num_to_display) n2;
          varexpTup';
-         pres_to_structured exp])
+         pres_to_display exp])
   /\
-  (pres_to_structured (Let' tra varexpTup exp) =
+  (pres_to_display (Let' tra varexpTup exp) =
     let varexpTup' = List (MAP (\ (v1, e) . Tuple [
-      string_to_structured v1;
-      pres_to_structured e
+      string_to_display v1;
+      pres_to_display e
     ]) varexpTup) in
       Item (SOME tra) "Let"
         [varexpTup';
-         pres_to_structured exp])
+         pres_to_display exp])
   /\
-  (pres_to_structured (Seq tra e1 e2) =
-    Item (SOME tra) "Seq" [pres_to_structured e1; pres_to_structured e2])
+  (pres_to_display (Seq tra e1 e2) =
+    Item (SOME tra) "Seq" [pres_to_display e1; pres_to_display e2])
   /\
-  (pres_to_structured (Call tra ticks dest es) =
+  (pres_to_display (Call tra ticks dest es) =
     Item (SOME tra) "Call"
-      [num_to_structured ticks;
-       num_to_structured dest;
-       List (MAP (\e. pres_to_structured e) es)])
+      [num_to_display ticks;
+       num_to_display dest;
+       List (MAP (\e. pres_to_display e) es)])
   /\
-  (pres_to_structured (App' tra n1 e exps) =
+  (pres_to_display (App' tra n1 e exps) =
       Item (SOME tra) "App"
-        [option_to_structured num_to_structured n1;
-         pres_to_structured e;
-         List (MAP (\e. pres_to_structured e) exps)]) /\
-  (pres_to_structured (CodeTable code_table) =
+        [option_to_display num_to_display n1;
+         pres_to_display e;
+         List (MAP (\e. pres_to_display e) exps)]) /\
+  (pres_to_display (CodeTable code_table) =
     Item NONE "CodeTable"
       [List (MAP (\(n,args,e).
-         Tuple [num_to_structured n;
-                list_to_structured string_to_structured args;
-                pres_to_structured e]) code_table)])`
+         Tuple [num_to_display n;
+                list_to_display string_to_display args;
+                pres_to_display e]) code_table)])`
  (WF_REL_TAC `measure exp_size` \\ rw []
   \\ imp_res_tac MEM_exp_size \\ fs []
   \\ imp_res_tac MEM_expTup_size \\ fs []
@@ -885,7 +884,7 @@ val lang_to_json_def = Define`
   lang_to_json langN func =
     \ p . Object [
       ("lang", String langN);
-      ("prog", structured_to_json (pres_to_structured (func p)))]`;
+      ("prog", display_to_json (pres_to_display (func p)))]`;
 
 val mod_to_json_def = Define`
   mod_to_json = lang_to_json "modLang" mod_to_pres`;

--- a/compiler/backend/presLangScript.sml
+++ b/compiler/backend/presLangScript.sml
@@ -683,7 +683,7 @@ val conf_to_structured_def = Define`
             Item NONE "SOME" [Tuple [num_to_structured n; tid_or_exn_to_structured t]]
          | Exhlang_con c => Item NONE "SOME" [num_to_structured c]`;
 
-(* Takes a presLang$exp and produces json$obj that mimics its structure. *)
+(* Takes a presLang$exp and produces jsonLang$obj that mimics its structure. *)
 
 val MEM_exp_size = prove(
   ``!xs x. MEM x xs ==> exp_size x < exp12_size xs``,

--- a/compiler/backend/structuredLangScript.sml
+++ b/compiler/backend/structuredLangScript.sml
@@ -1,4 +1,4 @@
-open preamble jsonTheory backend_commonTheory;
+open preamble jsonLangTheory backend_commonTheory;
 
 val _ = new_theory"structuredLang";
 


### PR DESCRIPTION
Rename `json` to `jsonLang` and `structuredLang` to `displayLang`.